### PR TITLE
Add mathjax directive and icon role.

### DIFF
--- a/blohg/rst_parser/directives.py
+++ b/blohg/rst_parser/directives.py
@@ -27,7 +27,7 @@ from blohg.rst_parser.nodes import iframe_flash_video
 import posixpath
 
 
-__all__ = ['Vimeo', 'Youtube', 'Math', 'Code', 'SourceCode', 'AttachmentImage',
+__all__ = ['Vimeo', 'Youtube', 'Math', 'MathJax', 'Code', 'SourceCode', 'AttachmentImage',
            'AttachmentFigure', 'SubPages', 'IncludeHg']
 
 GOOGLETEX_URL = 'https://chart.googleapis.com/chart?cht=tx&chl='
@@ -225,6 +225,47 @@ class Math(Image):
         return Image.run(self)
 
 
+class MathJax(Directive):
+    """reStructuredText directive that simply returns a math html fragment suitable for rendering by MathJax.
+
+    The latex math equations are simply wrapped by an HTML div tag with mathjax class for further CSS decoration.
+    Use conventional LaTeX to write math equations.
+    Note that $ signs or \begin{equation} etc. should be no longer omitted.
+    Auto-numbering is possible by configuring MathJax before loading MathJax, via::
+
+        <script type="text/x-mathjax-config">
+            MathJax.Hub.Config({
+                TeX: { equationNumbers: { autoNumber: "AMS" } }
+            });
+        </script>
+
+    Usage example::
+
+        .. mathjax::
+
+            $$\frac{x^2}{1+x}\label{frac_eq}$$
+
+    for a displayed numbered equation with a reference. Use "\eqref{frac_eq}" in normal way to cite the equation number.
+    LaTeX math \begin{equation}, \begin{align}, etc. are all supported.
+    See MathJax official websites for more information.
+    """
+
+    required_arguments = 0
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        html = '''\
+
+<div class="mathjax">
+%s
+</div>
+
+'''
+        return [nodes.raw('', html % (
+            "\n".join(self.content).replace('<', '&lt;'), ),
+            format='html')]
+
 
 class AttachmentImage(Image):
 
@@ -405,6 +446,7 @@ index = {
     'vimeo': Vimeo,
     'youtube': Youtube,
     'math': Math,
+    'mathjax': MathJax,
     'code': Code,
     'sourcecode': SourceCode,
     'attachment-image': AttachmentImage,

--- a/blohg/rst_parser/roles.py
+++ b/blohg/rst_parser/roles.py
@@ -9,6 +9,7 @@
     :license: GPL-2, see LICENSE for more details.
 """
 
+from docutils import nodes
 from docutils.nodes import reference, paragraph
 from flask import current_app, url_for
 
@@ -64,7 +65,18 @@ def page_role(name, rawtext, text, lineno, inliner, options={}, content={}):
     return [reference(url, title, refuri=url)], []
 
 
+def icon_role(name, rawtext, text, lineno, inliner, options={}, content={}):
+    """reStructuredText role to generate an icon in HTML <i class=""></i>
+    use as :icon:`icon class attribute`.
+    """
+    html = '''\
+<i class="%s"></i>
+'''
+    return [nodes.raw('', html % (text), format='html')], []
+
+
 index = {
     'attachment': attachment_role,
     'page': page_role,
+    'icon': icon_role,
 }


### PR DESCRIPTION
1. Now MathJax becomes more and more popular for displaying math equations. It displays math equations using native math fonts or web fonts and at the meantime the original TeX string is available to readers, while Google chart API only generates images of math equations which has lower resolution. This modification adds an mathjax directive which only wraps the TeX math string with an HTML div tag with "mathjax" class attributes which is convenient for further decoration by CSS. Actually, one can simply use the container directive in rst file like this
   `.. container:: mathjax`
   `$$ TeX math string $$`
   to obtain the same result.
2. I have encountered a great icon package font-awsome and found it really necessary to add an icon role to ease adding icon in rst files. To add an icon from font-awsome, add this line to your html source file:
   `<i class="fa fa-some-icon-name"></i>`.
   While without icon role, we need to use raw role, first define
   `.. role:: raw-html(raw)`
   `:format: html`
   Then use raw-html to add an a font-awsome icon:
   :raw-html:``<i class="fa fa-some-icon-name"></i>``
   while use icon role, we only need add this to the rst file:
   :icon:``fa fa-some-icon-name``
   It is also necessary to enhance icon role or to create a new role to generate an linkable icon, like
   `<a href="some link"><i class="fa fa-some-icon-name"></i></a>`
   Or even make a button like
   `<a href="some link" class="btn"><i class="fa fa-some-icon-name"></i></a>`
   But these are not done yet.
